### PR TITLE
Add disaggregation and polars interface therefore

### DIFF
--- a/src/cfa_subgroup_imputer/groups.py
+++ b/src/cfa_subgroup_imputer/groups.py
@@ -397,6 +397,7 @@ class GroupMap:
             measurement_type = None
             attribute_class = Attribute
             if col in count or col in rate:
+                impute_action = "impute"
                 measurement_type = "count" if col in count else "rate"
                 attribute_class = ImputableAttribute
             self.add_attribute(

--- a/src/cfa_subgroup_imputer/groups.py
+++ b/src/cfa_subgroup_imputer/groups.py
@@ -76,7 +76,7 @@ class Group:
         )
         measurement_names = [a.name for a in self.attributes]
         assert len(set(measurement_names)) == len(measurement_names), (
-            "Found multiple measurements for same attribute."
+            f"Found multiple measurements for same attribute when constructing group named {self.name}: {measurement_names}"
         )
         to_impute = set(
             a.name for a in self.attributes if a.impute_action == "impute"

--- a/src/cfa_subgroup_imputer/groups.py
+++ b/src/cfa_subgroup_imputer/groups.py
@@ -336,20 +336,8 @@ class GroupMap:
         for grp_name in group_names:
             self.group(grp_name).filter_on = filters
 
-    def density_to_mass(self, group_type: GroupType) -> Self:
-        """
-        Put all density measurements in super or subgroups on mass scale for ease of downstream manipulation.
-        """
-        raise NotImplementedError()
-
     def group(self, name: Hashable) -> Group:
         return self.groups[name]
-
-    def restore_densities(self, group_type: GroupType) -> Self:
-        """
-        Undo density_to_mass for selected measurements.
-        """
-        raise NotImplementedError()
 
     def data_to_polars(self, group_type: GroupType) -> pl.DataFrame:
         """
@@ -379,7 +367,7 @@ class GroupMap:
         Populates measurements and attributes for groups found in the dataframe.
         """
         if group_type == "subgroup":
-            raise NotImplementedError()
+            group_names = self.subgroup_names()
         elif group_type == "supergroup":
             group_names = self.supergroup_names
         else:

--- a/src/cfa_subgroup_imputer/groups.py
+++ b/src/cfa_subgroup_imputer/groups.py
@@ -189,6 +189,48 @@ class GroupMap:
         self.groups = {group.name: group for group in groups}
         self._validate()
 
+    @classmethod
+    def from_supergroups(
+        cls,
+        super_to_sub: dict[Hashable, Iterable[Hashable]],
+        groups: Iterable[Group],
+    ) -> Self:
+        """
+        Alternative constructor, takes in a supergroup : [subgroups] dict.
+        """
+        sub_to_super = GroupMap.make_many_to_one(super_to_sub)
+        return cls(sub_to_super, groups)
+
+    def _assert_names_unique(self) -> None:
+        """
+        Ensure that super and subgroup names are all unique.
+        """
+        group_names = [group.name for group in self.groups.values()]
+        repeats = [
+            name for name, count in Counter(group_names).items() if count > 1
+        ]
+        assert len(repeats) == 0, (
+            f"The following group names are not unique: {repeats}"
+        )
+
+    def _assert_no_missing_data(self) -> None:
+        """
+        Ensure that each supergroup's size is the sum of constituent subgroup sizes.
+        """
+        raise NotImplementedError()
+
+    def _assert_no_missing_population(self, size_from: Hashable) -> None:
+        """
+        Ensure that each supergroup's size is the sum of constituent subgroup sizes.
+        """
+        raise NotImplementedError()
+
+    def _validate(self):
+        self._assert_names_unique()
+        # @TODO: Should these be done at (dis)aggregation time outside this class?
+        # self._assert_no_missing_population()
+        # self._assert_no_missing_data()
+
     def add_attribute(
         self,
         group_type: GroupType,

--- a/src/cfa_subgroup_imputer/imputer.py
+++ b/src/cfa_subgroup_imputer/imputer.py
@@ -2,34 +2,85 @@
 Module for imputation machinery.
 """
 
-from typing import Protocol
+from math import isclose
+from typing import Hashable, Protocol
 
 from cfa_subgroup_imputer.groups import (
     Group,
     GroupMap,
 )
+from cfa_subgroup_imputer.variables import Range, assert_range_spanned_exactly
 
 
 class ProportionCalculator(Protocol):
-    def calculate(self, supergroup_name: str) -> dict[str, float]: ...
+    def calculate(
+        self, supergroup_name: Hashable, group_map: GroupMap, **kwargs
+    ) -> dict[Hashable, float]: ...
 
 
 class ProportionsFromCategories:
-    def __init__(self, proportions_from: str):
-        self.varname = proportions_from
+    def __init__(self, size_from: Hashable):
+        self.size_from = size_from
 
     def relative_proportion(self, group: Group):
-        rel_prop = group.get_attribute(self.varname)
+        rel_prop = group.get_attribute(self.size_from)
         assert rel_prop.value >= 0.0
         return rel_prop.value
 
-    def calculate(self, supergroup_name: str) -> dict[str, float]:
-        raise NotImplementedError()
+    def calculate(
+        self, supergroup_name: Hashable, group_map: GroupMap, **kwargs
+    ) -> dict[Hashable, float]:
+        wt = {
+            grp: self.relative_proportion(group_map.group(grp))
+            for grp in group_map.subgroup_names(supergroup_name)
+        }
+        wt_sum = sum(wt.values())
+
+        supergroup_size = (
+            group_map.group(supergroup_name)
+            .get_attribute(self.size_from)
+            .value
+        )
+        normalize = kwargs.get("normalize", False)
+        rel_tol = kwargs.get("rel_tol", 1e-6)
+
+        if (not isclose(wt_sum, supergroup_size, rel_tol=rel_tol)) and (
+            not normalize
+        ):
+            raise RuntimeError(
+                f"Subgroup sizes sum to {wt_sum} while supergroup size is {supergroup_size}"
+            )
+
+        wt = {k: v / wt_sum for k, v in wt.items()}
+        return wt
 
 
 class ProportionsFromContinuous:
-    def calculate(self, supergroup_name: str) -> dict[str, float]:
-        raise NotImplementedError()
+    def __init__(self, var_name: str):
+        self.var_name = var_name
+
+    def calculate(
+        self, supergroup_name: Hashable, group_map: GroupMap, **kwargs
+    ) -> dict[Hashable, float]:
+        ranges: dict[Hashable, Range] = {
+            grp: group_map.group(grp).get_attribute(self.var_name).value
+            for grp in group_map.subgroup_names(supergroup_name)
+        }
+        supergroup_range = (
+            group_map.group(supergroup_name).get_attribute(self.var_name).value
+        )
+        assert all(isinstance(r, Range) for r in ranges) and isinstance(
+            supergroup_range, Range
+        ), (
+            "Cannot disaggregate continuous variables unless the attribute is a `Range` object."
+        )
+        assert_range_spanned_exactly(supergroup_range, ranges.values())
+
+        wt = {k: v.duration() for k, v in ranges.items()}
+        wt_sum = sum(wt.values())
+
+        wt = {k: v / wt_sum for k, v in wt.items()}
+        return wt
 
 
 class Disaggregator:
@@ -37,22 +88,27 @@ class Disaggregator:
     A class which imputes and disaggregates subgroups.
     """
 
-    def __init__(self, weight_calculator: ProportionCalculator):
-        self.weight_calculator = weight_calculator
+    def __init__(self, proportion_calculator: ProportionCalculator):
+        self.proportion_calculator = proportion_calculator
 
     def __call__(self, map: GroupMap) -> GroupMap:
         """
         Impute and disaggregate the given group map.
         """
         assert map.disaggregatable
-        raise NotImplementedError()
-        # all_mass = map.density_to_mass("supergroup")
-        # imputed_groups = [map.group(name) for name in all_mass.supergroups]
-        # for supergroup_name in all_mass.supergroups:
-        # weights = self.weight_calculator.calculate(supergroup_name)
-        # TODO: use weights to apportion the supergroup measurements to the subgroups
-        # TODO: add the new data-inclusive subgroup to the list
 
-        # return GroupMap(
-        #     all_mass.sub_to_super, imputed_groups
-        # ).restore_densities("subgroup")
+        sub_to_super = map.sub_to_super
+        groups = []
+
+        for supergroup_name in map.supergroup_names:
+            supergroup = map.group(supergroup_name)
+            groups.append(supergroup)
+            props = self.proportion_calculator.calculate(supergroup_name, map)
+            for grp_name in map.subgroup_names(supergroup_name):
+                groups.append(
+                    supergroup.disaggregate_one_subgroup(
+                        map.group(grp_name), props[grp_name]
+                    )
+                )
+
+        return GroupMap(sub_to_super, groups)

--- a/src/cfa_subgroup_imputer/imputer.py
+++ b/src/cfa_subgroup_imputer/imputer.py
@@ -56,8 +56,8 @@ class ProportionsFromCategories:
 
 
 class ProportionsFromContinuous:
-    def __init__(self, var_name: str):
-        self.var_name = var_name
+    def __init__(self, continuous_var_name: str):
+        self.var_name = continuous_var_name
 
     def calculate(
         self, supergroup_name: Hashable, group_map: GroupMap, **kwargs

--- a/src/cfa_subgroup_imputer/imputer.py
+++ b/src/cfa_subgroup_imputer/imputer.py
@@ -95,7 +95,6 @@ class Disaggregator:
         """
         Impute and disaggregate the given group map.
         """
-        assert map.disaggregatable
 
         sub_to_super = map.sub_to_super
         groups = []

--- a/src/cfa_subgroup_imputer/imputer.py
+++ b/src/cfa_subgroup_imputer/imputer.py
@@ -69,9 +69,9 @@ class ProportionsFromContinuous:
         supergroup_range = (
             group_map.group(supergroup_name).get_attribute(self.var_name).value
         )
-        assert all(isinstance(r, Range) for r in ranges) and isinstance(
-            supergroup_range, Range
-        ), (
+        assert all(
+            isinstance(r, Range) for r in ranges.values()
+        ) and isinstance(supergroup_range, Range), (
             "Cannot disaggregate continuous variables unless the attribute is a `Range` object."
         )
         assert_range_spanned_exactly(supergroup_range, ranges.values())

--- a/src/cfa_subgroup_imputer/mapping.py
+++ b/src/cfa_subgroup_imputer/mapping.py
@@ -318,7 +318,7 @@ class AgeGroupHandler:
             attribute_values={
                 subgrp: self.age_range_from_str(subgrp) for subgrp in subgroups
             },
-            attribute_filter_values={subgrp: subgrp for subgrp in subgroups},
+            attribute_polars_values={subgrp: subgrp for subgrp in subgroups},
             impute_action="ignore",
             attribute_class=Attribute,
         )
@@ -329,7 +329,7 @@ class AgeGroupHandler:
                 supergrp: self.age_range_from_str(supergrp)
                 for supergrp in supergroups
             },
-            attribute_filter_values={
+            attribute_polars_values={
                 supergrp: supergrp for supergrp in supergroups
             },
             impute_action="ignore",

--- a/src/cfa_subgroup_imputer/mapping.py
+++ b/src/cfa_subgroup_imputer/mapping.py
@@ -108,6 +108,9 @@ class RaggedOuterProductSubgroupHandler(ABC):
                 measurement_type=None,
             )
 
+        group_map.add_filters("supergroup", [variable_names[-1]])
+        group_map.add_filters("subgroup", variable_names)
+
         return group_map
 
 
@@ -334,6 +337,9 @@ class AgeGroupHandler:
             Range(sorted_super_ranges[0].lower, sorted_super_ranges[-1].upper),
             sorted_super_ranges,
         )
+
+        grp_map.add_filters("supergroup", [age_varname])
+        grp_map.add_filters("subgroup", [age_varname])
 
         return grp_map
 

--- a/src/cfa_subgroup_imputer/mapping.py
+++ b/src/cfa_subgroup_imputer/mapping.py
@@ -284,7 +284,7 @@ class AgeGroupHandler:
         subgroups: Iterable[str],
         **kwargs,
     ) -> GroupMap:
-        age_varname = kwargs.get("variable_name", "age")
+        age_varname = kwargs.get("continuous_var_name", "age")
         missing_option = kwargs.get("missing_option", "error")
 
         # Brute force attribution

--- a/src/cfa_subgroup_imputer/mapping.py
+++ b/src/cfa_subgroup_imputer/mapping.py
@@ -318,6 +318,7 @@ class AgeGroupHandler:
             attribute_values={
                 subgrp: self.age_range_from_str(subgrp) for subgrp in subgroups
             },
+            attribute_filter_values={subgrp: subgrp for subgrp in subgroups},
             impute_action="ignore",
             attribute_class=Attribute,
         )
@@ -327,6 +328,9 @@ class AgeGroupHandler:
             attribute_values={
                 supergrp: self.age_range_from_str(supergrp)
                 for supergrp in supergroups
+            },
+            attribute_filter_values={
+                supergrp: supergrp for supergrp in supergroups
             },
             impute_action="ignore",
             attribute_class=Attribute,

--- a/src/cfa_subgroup_imputer/polars.py
+++ b/src/cfa_subgroup_imputer/polars.py
@@ -59,6 +59,7 @@ def create_group_map(
         )
     elif group_type == "age":
         # TODO: we could rename this ourselves, instead of erroring out
+        #       though then we'd have to tweak the written output at the end too
         assert supergroups_from == subgroups_from, (
             "Age groups must be named identically in super and subgroup dataframes"
         )
@@ -116,8 +117,12 @@ def disaggregate(
             size_from=kwargs.get("size_from", "size")
         )
     elif group_type == "age":
+        # TODO: as above we could rename this ourselves
+        assert supergroups_from == subgroups_from, (
+            "Age groups must be named identically in super and subgroup dataframes"
+        )
         prop_calc = ProportionsFromContinuous(
-            continuous_var_name=kwargs.get("continuous_var_name", "age")
+            continuous_var_name=subgroups_from
         )
     else:
         raise RuntimeError(f"Unknown grouping variable type {group_type}")

--- a/src/cfa_subgroup_imputer/polars.py
+++ b/src/cfa_subgroup_imputer/polars.py
@@ -76,6 +76,7 @@ def create_group_map(
 
 def disaggregate(
     supergroup_df: pl.DataFrame,
+    # TODO: we should perhaps let this be just a list of values for splitting on age
     subgroup_df: pl.DataFrame,
     subgroup_to_supergroup: pl.DataFrame | None,
     supergroups_from: str,
@@ -137,7 +138,7 @@ def disaggregate(
             "df": subgroup_df,
             "groups_from": [subgroups_from] + [supergroups_from]
             if group_type == "categorical"
-            else [],
+            else [subgroups_from],
             "n_groups": len(group_map.subgroup_names()),
         },
     }.items():

--- a/src/cfa_subgroup_imputer/polars.py
+++ b/src/cfa_subgroup_imputer/polars.py
@@ -157,13 +157,18 @@ def disaggregate(
             f"Dataframe has multiple entries for at least one combination of group-defining variables ({grp_info['groups_from']}) and variables to loop over ({loop_over}).\n{grp_info['df']}"
         )
 
-    # If we're not told what to do with the column, copy it
+    # If we're not told what to do with the column, and it's not being used to compute proportions, copy it
+    if subgroup_to_supergroup is not None or group_type == "categorical":
+        ignore = [kwargs.get("size_from", "size")]
+    elif group_type == "age":
+        ignore = [kwargs.get("continuous_var_name", "age")]
     copy = (
         set(supergroup_df.columns)
         .difference(safe_loop_over)
         .difference(exclude)
         .difference(rate)
         .difference(count)
+        .difference(ignore)
     )
     disagg_comp = []
     for supergroup_dfg, subgroup_dfg in zip(

--- a/src/cfa_subgroup_imputer/polars.py
+++ b/src/cfa_subgroup_imputer/polars.py
@@ -53,13 +53,22 @@ def create_group_map(
         return OuterProductSubgroupHandler().construct_group_map(
             supergroup_categories=supergroup_cats,
             subgroup_categories=[subgroup_cats],
+            supergroup_variable_name=supergroups_from,
+            subgroup_variable_names=[subgroups_from],
             **kwargs,
         )
     elif group_type == "age":
+        # TODO: we could rename this ourselves, instead of erroring out
+        assert supergroups_from == subgroups_from, (
+            "Age groups must be named identically in super and subgroup dataframes"
+        )
         return AgeGroupHandler(
             age_max=kwargs.get("age_max", 100)
         ).construct_group_map(
-            supergroups=supergroup_cats, subgroups=subgroup_cats, **kwargs
+            supergroups=supergroup_cats,
+            subgroups=subgroup_cats,
+            continuous_var_name=subgroups_from,
+            **kwargs,
         )
     else:
         raise RuntimeError(f"Unknown grouping variable type {group_type}")

--- a/src/cfa_subgroup_imputer/polars.py
+++ b/src/cfa_subgroup_imputer/polars.py
@@ -55,6 +55,9 @@ def create_group_map(
         raise RuntimeError(f"Unknown grouping variable type {group_type}")
 
 
+# def populate_disaggregatable_data()
+
+
 def disaggregate(
     supergroup_df: pl.DataFrame,
     subgroup_df: pl.DataFrame,

--- a/src/cfa_subgroup_imputer/polars.py
+++ b/src/cfa_subgroup_imputer/polars.py
@@ -169,8 +169,10 @@ def disaggregate(
         .difference(rate)
         .difference(count)
         .difference(ignore)
+        # TODO: this is somewhat redundant with data_from_polars knowing not to copy group-defining variables
+        .difference([supergroups_from])
     )
-    disagg_comp = []
+    disagg_df_comp = []
     for supergroup_dfg, subgroup_dfg in zip(
         supergroup_df.group_by(safe_loop_over),
         subgroup_df.group_by(safe_loop_over),
@@ -194,6 +196,7 @@ def disaggregate(
             rate=rate,
         )
 
-        disagg_comp.append(disaggregator(grp_map).data_to_polars("subgroup"))
+        disagg_map = disaggregator(grp_map)
+        disagg_df_comp.append(disagg_map.data_to_polars("subgroup"))
 
-    return pl.concat(disagg_comp).drop("dummy")
+    return pl.concat(disagg_df_comp).drop("dummy")

--- a/src/cfa_subgroup_imputer/variables.py
+++ b/src/cfa_subgroup_imputer/variables.py
@@ -42,7 +42,7 @@ class Attribute:
         value: Any,
         name: Hashable,
         impute_action: ImputeAction,
-        filter_value: Any | None = None,
+        polars_value: Any | None = None,
     ):
         """
         Attribute constructor.
@@ -56,13 +56,13 @@ class Attribute:
         impute_action: ImputeAction
             What should we do with this measurement when disaggregating?
             Note that just because we can impute it doesn't mean we will.
-        filter_value : Any
+        polars_value : Any
             If the `value` is not something recorded directly in a dataframe,
-            this specifies how a polars filter will be constructed to match
-            instances of this attribute. None means to use the value.
+            this specifies how to compare to values in polars dataframes and
+            how to output this value to a dataframe.  None means to use the value.
         """
         self.value = value
-        self.filter_value = filter_value if filter_value is not None else value
+        self.polars_value = polars_value if polars_value is not None else value
         self.name: Hashable = name
         self.impute_action: ImputeAction = impute_action
         self._validate()
@@ -71,12 +71,12 @@ class Attribute:
         return (
             self.name == x.name
             and self.value == x.value
-            and self.filter_value == x.filter_value
+            and self.polars_value == x.polars_value
             and self.impute_action == x.impute_action
         )
 
     def __repr__(self):
-        return f"Attribute(name={self.name}, impute_action={self.impute_action}, value={self.value}, filter_value={self.filter_value})"
+        return f"Attribute(name={self.name}, impute_action={self.impute_action}, value={self.value}, polars_value={self.polars_value})"
 
     def _validate(self):
         assert isinstance(self.name, Hashable)
@@ -95,7 +95,7 @@ class ImputableAttribute(Attribute):
         name: Hashable,
         impute_action: ImputeAction,
         measurement_type: MeasurementType,
-        filter_value: Any | None = None,
+        polars_value: Any | None = None,
     ):
         """
         ImputableAttribute constructor.
@@ -111,17 +111,17 @@ class ImputableAttribute(Attribute):
             Note that just because we can impute it doesn't mean we will.
         type: MeasurementType
             What kind of imputable attribute is this?
-        filter_value : Any
+        polars_value : Any
             If the `value` is not something recorded directly in a dataframe,
-            this specifies how a polars filter will be constructed to match
-            instances of this attribute. None means to use the value.
+            this specifies how to compare to values in polars dataframes and
+            how to output this value to a dataframe.  None means to use the value.
         """
         assert value >= 0.0
         super().__init__(
             value=value,
             name=name,
             impute_action=impute_action,
-            filter_value=filter_value,
+            polars_value=polars_value,
         )
         self.measurement_type: MeasurementType = measurement_type
         assert self.measurement_type in get_args(MeasurementType)

--- a/src/cfa_subgroup_imputer/variables.py
+++ b/src/cfa_subgroup_imputer/variables.py
@@ -42,6 +42,7 @@ class Attribute:
         value: Any,
         name: Hashable,
         impute_action: ImputeAction,
+        filter_value: Any | None = None,
     ):
         """
         Attribute constructor.
@@ -55,8 +56,13 @@ class Attribute:
         impute_action: ImputeAction
             What should we do with this measurement when disaggregating?
             Note that just because we can impute it doesn't mean we will.
+        filter_value : Any
+            If the `value` is not something recorded directly in a dataframe,
+            this specifies how a polars filter will be constructed to match
+            instances of this attribute. None means to use the value.
         """
         self.value = value
+        self.filter_value = filter_value if filter_value is not None else value
         self.name: Hashable = name
         self.impute_action: ImputeAction = impute_action
         self._validate()
@@ -65,11 +71,12 @@ class Attribute:
         return (
             self.name == x.name
             and self.value == x.value
+            and self.filter_value == x.filter_value
             and self.impute_action == x.impute_action
         )
 
     def __repr__(self):
-        return f"Attribute(name={self.name}, impute_action={self.impute_action}, value={self.value})"
+        return f"Attribute(name={self.name}, impute_action={self.impute_action}, value={self.value}, filter_value={self.filter_value})"
 
     def _validate(self):
         assert isinstance(self.name, Hashable)
@@ -88,6 +95,7 @@ class ImputableAttribute(Attribute):
         name: Hashable,
         impute_action: ImputeAction,
         measurement_type: MeasurementType,
+        filter_value: Any | None = None,
     ):
         """
         ImputableAttribute constructor.
@@ -103,9 +111,18 @@ class ImputableAttribute(Attribute):
             Note that just because we can impute it doesn't mean we will.
         type: MeasurementType
             What kind of imputable attribute is this?
+        filter_value : Any
+            If the `value` is not something recorded directly in a dataframe,
+            this specifies how a polars filter will be constructed to match
+            instances of this attribute. None means to use the value.
         """
         assert value >= 0.0
-        super().__init__(value, name, impute_action)
+        super().__init__(
+            value=value,
+            name=name,
+            impute_action=impute_action,
+            filter_value=filter_value,
+        )
         self.measurement_type: MeasurementType = measurement_type
         assert self.measurement_type in get_args(MeasurementType)
 

--- a/src/cfa_subgroup_imputer/variables.py
+++ b/src/cfa_subgroup_imputer/variables.py
@@ -11,10 +11,10 @@ from typing import (
     get_args,
 )
 
-MassMeasurementType = Literal["mass", "mass_from_density"]
-DensityMeasurementType = Literal["density", "density_from_mass"]
+CountMeasurementType = Literal["count", "count_from_rate"]
+RateMeasurementType = Literal["rate", "rate_from_count"]
 MeasurementType = Literal[
-    "mass", "density", "mass_from_density", "density_from_mass"
+    "count", "rate", "count_from_rate", "rate_from_count"
 ]
 """
 How a measurement behaves for disaggregation.
@@ -94,7 +94,7 @@ class ImputableAttribute(Attribute):
 
         Parameters
         ----------
-        value : float
+        value : float | int
             The value, e.g. a number of cases.
         name : Hashable
             What is this variable? E.g., "size" or "vaccination rate"
@@ -113,7 +113,10 @@ class ImputableAttribute(Attribute):
         assert self.impute_action in get_args(ImputeAction)
 
     def __eq__(self, x):
-        return super().__eq__() and self.measurement_type == x.measurement_type
+        # @TODO: should we check strict equality? allow RateType == RateType? make a toggle? add .equivalent()?
+        return (
+            super().__eq__(x) and self.measurement_type == x.measurement_type
+        )
 
     def __mul__(self, k: float) -> Self:
         return type(self)(
@@ -128,7 +131,7 @@ class ImputableAttribute(Attribute):
             value=self.value * size,
             name=self.name,
             impute_action=self.impute_action,
-            measurement_type="mass_from_density",
+            measurement_type="count_from_rate",
         )
 
     def to_rate(self, volume: float) -> Self:
@@ -136,7 +139,7 @@ class ImputableAttribute(Attribute):
             value=self.value / volume,
             name=self.name,
             impute_action=self.impute_action,
-            measurement_type="density_from_mass",
+            measurement_type="rate_from_count",
         )
 
 
@@ -186,6 +189,9 @@ class Range:
 
     def __repr__(self):
         return f"Range({self.lower},{self.upper})"
+
+    def duration(self) -> float:
+        return self.upper - self.lower
 
     @classmethod
     def from_tuple(cls, low_high: tuple[float, float]):

--- a/tests/test_disaggregator.py
+++ b/tests/test_disaggregator.py
@@ -154,7 +154,9 @@ def test_disaggregator_age_continuous():
     )
 
     # 4. Disaggregate using ProportionsFromContinuous
-    disaggregator = Disaggregator(ProportionsFromContinuous(var_name="age"))
+    disaggregator = Disaggregator(
+        ProportionsFromContinuous(continuous_var_name="age")
+    )
     result_map = disaggregator(group_map)
 
     # 5. Verify the results

--- a/tests/test_disaggregator.py
+++ b/tests/test_disaggregator.py
@@ -1,0 +1,107 @@
+# import pytest
+# from cfa_subgroup_imputer.groups import Group, GroupMap
+# from cfa_subgroup_imputer.variables import Attribute, ImputableAttribute
+# from cfa_subgroup_imputer.imputer import (
+#     Disaggregator,
+#     ProportionsFromCategories,
+# )
+# from cfa_subgroup_imputer.mapping import OuterProductSubgroupHandler
+
+
+# def test_disaggregator_outer_product():
+#     # Define two supergroups and three subgroups
+#     supergroups = ["A", "B"]
+#     subgroups = ["x", "y", "z"]
+#     # Assign sizes to each subgroup within each supergroup
+#     subgroup_sizes = {
+#         ("A", "x"): 10,
+#         ("A", "y"): 20,
+#         ("A", "z"): 30,
+#         ("B", "x"): 40,
+#         ("B", "y"): 50,
+#         ("B", "z"): 60,
+#     }
+#     supergroup_sizes = {
+#         "A": sum(subgroup_sizes[("A", s)] for s in subgroups),
+#         "B": sum(subgroup_sizes[("B", s)] for s in subgroups),
+#     }
+
+#     # Build group map using OuterProductSubgroupHandler
+#     handler = OuterProductSubgroupHandler()
+#     group_map = handler.construct_group_map(
+#         supergroups=supergroups,
+#         subgroups=subgroups,
+#         supergroup_varname="region",
+#         subgroup_varname="category",
+#     )
+
+#     # Add size attributes to groups
+#     groups = []
+#     for group in group_map.groups.values():
+#         if group.name in supergroups:
+#             # Supergroup
+#             groups.append(
+#                 Group(
+#                     name=group.name,
+#                     attributes=[
+#                         Attribute(
+#                             value=group.name,
+#                             name="region",
+#                             impute_action="ignore",
+#                         ),
+#                         Attribute(
+#                             value=supergroup_sizes[group.name],
+#                             name="size",
+#                             impute_action="ignore",
+#                         ),
+#                     ],
+#                 )
+#             )
+#         else:
+#             # Subgroup
+#             region = group.get_attribute("region").value
+#             category = group.get_attribute("category").value
+#             groups.append(
+#                 Group(
+#                     name=group.name,
+#                     attributes=[
+#                         Attribute(
+#                             value=region, name="region", impute_action="ignore"
+#                         ),
+#                         Attribute(
+#                             value=category,
+#                             name="category",
+#                             impute_action="ignore",
+#                         ),
+#                         Attribute(
+#                             value=subgroup_sizes[(region, category)],
+#                             name="size",
+#                             impute_action="ignore",
+#                         ),
+#                     ],
+#                 )
+#             )
+#     group_map = GroupMap(group_map.sub_to_super, groups)
+
+#     # Mark group map as disaggregatable by monkeypatching if needed
+#     # (Assume for this test that disaggregatable is not implemented)
+#     group_map.disaggregatable = True
+
+#     # Run Disaggregator
+#     disagg = Disaggregator(ProportionsFromCategories(size_from="size"))
+#     result = disagg(group_map)
+
+#     # Check that each subgroup in result has the correct size
+#     for supergroup in supergroups:
+#         total = 0
+#         for subgroup in subgroups:
+#             name = f"{supergroup}_{subgroup}"
+#             g = result.group(name)
+#             size = g.get_attribute("size").value
+#             assert size == pytest.approx(
+#                 subgroup_sizes[(supergroup, subgroup)]
+#             )
+#             total += size
+#         # Supergroup size should match sum of subgroups
+#         super_size = result.group(supergroup).get_attribute("size").value
+#         assert super_size == pytest.approx(total)

--- a/tests/test_disaggregator.py
+++ b/tests/test_disaggregator.py
@@ -153,14 +153,11 @@ def test_disaggregator_age_continuous():
         measurement_type="count",
     )
 
-    # 4. Disaggregate using ProportionsFromContinuous
     disaggregator = Disaggregator(
         ProportionsFromContinuous(continuous_var_name="age")
     )
     result_map = disaggregator(group_map)
 
-    # 5. Verify the results
-    # Check that total size is conserved
     total_size_before = sum(supergroup_sizes.values())
     total_size_after = sum(
         result_map.group(sg_name).get_attribute("size").value

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -134,7 +134,6 @@ class TestGroup:
         child = parent.disaggregate_one_subgroup(
             subgroup=child_precursor, prop=0.42
         )
-        print(child)
 
         assert child == child_expected
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cfa_subgroup_imputer.groups import Group
+from cfa_subgroup_imputer.groups import Group, GroupMap
 from cfa_subgroup_imputer.variables import Attribute, ImputableAttribute
 
 
@@ -137,3 +137,69 @@ class TestGroup:
         print(child)
 
         assert child == child_expected
+
+
+class TestGroupMap:
+    def test_add_attribute(self):
+        group_map = GroupMap(
+            sub_to_super={
+                "subgroup1": "supergroup1",
+                "subgroup2": "supergroup1",
+            },
+            groups=[
+                Group(name="supergroup1", attributes=[]),
+                Group(name="subgroup1", attributes=[]),
+                Group(name="subgroup2", attributes=[]),
+            ],
+        )
+
+        group_map.add_attribute(
+            group_type="subgroup",
+            attribute_name="new_attribute",
+            attribute_values={"subgroup1": "value1", "subgroup2": "value2"},
+            impute_action="ignore",
+            attribute_class=Attribute,
+        )
+
+        group_map.add_attribute(
+            group_type="supergroup",
+            attribute_name="other_attribute",
+            attribute_values={"supergroup1": "value0"},
+            impute_action="ignore",
+            attribute_class=Attribute,
+        )
+
+        groups_expected = {
+            "supergroup1": Group(
+                name="supergroup1",
+                attributes=[
+                    Attribute(
+                        name="other_attribute",
+                        value="value0",
+                        impute_action="ignore",
+                    )
+                ],
+            ),
+            "subgroup1": Group(
+                name="subgroup1",
+                attributes=[
+                    Attribute(
+                        name="new_attribute",
+                        value="value1",
+                        impute_action="ignore",
+                    )
+                ],
+            ),
+            "subgroup2": Group(
+                name="subgroup2",
+                attributes=[
+                    Attribute(
+                        name="new_attribute",
+                        value="value2",
+                        impute_action="ignore",
+                    )
+                ],
+            ),
+        }
+
+        assert group_map.groups == groups_expected

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -80,7 +80,7 @@ class TestAgeGroups:
                         name="age",
                         value=Range(0, 1),
                         impute_action="ignore",
-                        filter_value="0 years",
+                        polars_value="0 years",
                     )
                 ],
             ),
@@ -91,7 +91,7 @@ class TestAgeGroups:
                         name="age",
                         value=Range(1, 2),
                         impute_action="ignore",
-                        filter_value="1-<2 years",
+                        polars_value="1-<2 years",
                     )
                 ],
             ),
@@ -102,7 +102,7 @@ class TestAgeGroups:
                         name="age",
                         value=Range(0, 6.0 / 12.0),
                         impute_action="ignore",
-                        filter_value="0-<6 months",
+                        polars_value="0-<6 months",
                     )
                 ],
             ),
@@ -113,7 +113,7 @@ class TestAgeGroups:
                         name="age",
                         value=Range(6.0 / 12.0, 1.0),
                         impute_action="ignore",
-                        filter_value="6 months-<1 year",
+                        polars_value="6 months-<1 year",
                     )
                 ],
             ),
@@ -124,7 +124,7 @@ class TestAgeGroups:
                         name="age",
                         value=Range(1, 2),
                         impute_action="ignore",
-                        filter_value="1 year",
+                        polars_value="1 year",
                     )
                 ],
             ),

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -77,7 +77,10 @@ class TestAgeGroups:
                 name="0 years",
                 attributes=[
                     Attribute(
-                        name="age", value=Range(0, 1), impute_action="ignore"
+                        name="age",
+                        value=Range(0, 1),
+                        impute_action="ignore",
+                        filter_value="0 years",
                     )
                 ],
             ),
@@ -85,7 +88,10 @@ class TestAgeGroups:
                 name="1-<2 years",
                 attributes=[
                     Attribute(
-                        name="age", value=Range(1, 2), impute_action="ignore"
+                        name="age",
+                        value=Range(1, 2),
+                        impute_action="ignore",
+                        filter_value="1-<2 years",
                     )
                 ],
             ),
@@ -96,6 +102,7 @@ class TestAgeGroups:
                         name="age",
                         value=Range(0, 6.0 / 12.0),
                         impute_action="ignore",
+                        filter_value="0-<6 months",
                     )
                 ],
             ),
@@ -106,6 +113,7 @@ class TestAgeGroups:
                         name="age",
                         value=Range(6.0 / 12.0, 1.0),
                         impute_action="ignore",
+                        filter_value="6 months-<1 year",
                     )
                 ],
             ),
@@ -113,7 +121,10 @@ class TestAgeGroups:
                 name="1 year",
                 attributes=[
                     Attribute(
-                        name="age", value=Range(1, 2), impute_action="ignore"
+                        name="age",
+                        value=Range(1, 2),
+                        impute_action="ignore",
+                        filter_value="1 year",
                     )
                 ],
             ),

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -245,44 +245,44 @@ def test_disagg_ragged_categorical(state_data):
     )
 
 
-# def test_disagg_continuous_age(age_group_data, age_subgroups):
-#     disagg = disaggregate(
-#         supergroup_df=age_group_data,
-#         subgroup_df=age_subgroups,
-#         subgroup_to_supergroup=None,
-#         supergroups_from="age_group",
-#         subgroups_from="age_group",
-#         group_type="age",
-#         loop_over=[],
-#         rate=["vaccination_rate"],
-#         count=["cases", "size"],
-#         copy=["collection_date"],
-#         exclude=["notes", "to_exclude"],
-#     )
+def test_disagg_continuous_age(age_group_data, age_subgroups):
+    disagg = disaggregate(
+        supergroup_df=age_group_data,
+        subgroup_df=age_subgroups,
+        subgroup_to_supergroup=None,
+        supergroups_from="age_group",
+        subgroups_from="age_group",
+        group_type="age",
+        loop_over=[],
+        rate=["vaccination_rate"],
+        count=["cases", "size"],
+        copy=["collection_date"],
+        exclude=["notes", "to_exclude"],
+    )
 
-#     expected_disagg = pl.DataFrame(
-#         {
-#             "age_group": [
-#                 "0-4 years",
-#                 "5-17 years",
-#                 "18-64 years",
-#                 "65+ years",
-#             ],
-#             "size": [500.0, 1300.0, 4700.0, 3500.0],
-#             "cases": [50.0, 130.0, 470.0, 350.0],
-#             "vaccination_rate": [0.4, 0.4, 0.8, 0.8],
-#             "collection_date": [
-#                 "2024-01-01",
-#                 "2024-01-01",
-#                 "2024-01-01",
-#                 "2024-01-01",
-#             ],
-#         }
-#     )
+    expected_disagg = pl.DataFrame(
+        {
+            "age_group": [
+                "0-4 years",
+                "5-17 years",
+                "18-64 years",
+                "65+ years",
+            ],
+            "size": [500.0, 1300.0, 4700.0, 3500.0],
+            "cases": [50.0, 130.0, 470.0, 350.0],
+            "vaccination_rate": [0.4, 0.4, 0.8, 0.8],
+            "collection_date": [
+                "2024-01-01",
+                "2024-01-01",
+                "2024-01-01",
+                "2024-01-01",
+            ],
+        }
+    )
 
-#     assert_frame_equal(
-#         disagg,
-#         expected_disagg,
-#         check_row_order=False,
-#         check_column_order=False,
-#     )
+    assert_frame_equal(
+        disagg,
+        expected_disagg,
+        check_row_order=False,
+        check_column_order=False,
+    )

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -153,7 +153,7 @@ def test_disagg(state_data):
         }
     )
 
-    _ = disaggregate(
+    disagg = disaggregate(
         supergroup_df=state_data,
         subgroup_df=subgroup_df,
         subgroup_to_supergroup=None,
@@ -161,7 +161,30 @@ def test_disagg(state_data):
         subgroups_from="splitvar",
         group_type="categorical",
         loop_over=[],
-        rate=[],
-        count=[],
+        rate=["some_rate"],
+        count=["some_count"],
         exclude=["to_exclude", "to_ignore"],
+    )
+
+    expected_disagg = pl.DataFrame(
+        {
+            "state": ["California", "California", "Washington", "Washington"],
+            "splitvar": ["cat1", "cat2", "cat1", "cat2"],
+            "size": [20, 20, 2, 6],
+            "flower": [
+                "Eschscholzia californica",
+                "Eschscholzia californica",
+                "Rhododendron macrophyllum",
+                "Rhododendron macrophyllum",
+            ],
+            "some_rate": [1.2, 1.2, 1.3, 1.3],
+            "some_count": [5.0, 5.0, 5.0, 15.0],
+        }
+    )
+
+    assert_frame_equal(
+        disagg,
+        expected_disagg,
+        check_row_order=False,
+        check_column_order=False,
     )

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -192,11 +192,11 @@ def test_data_io_age_groups(age_subgroups, age_group_data):
         copy=["collection_date"],
     )
 
-    # df = age_group_map.data_to_polars("supergroup")
+    df = age_group_map.data_to_polars("supergroup")
 
-    # assert_frame_equal(
-    #     age_group_data.drop(["to_exclude", "notes"]), df, check_row_order=False
-    # )
+    assert_frame_equal(
+        age_group_data.drop(["to_exclude", "notes"]), df, check_row_order=False
+    )
 
 
 def test_disagg_ragged_categorical(state_data):
@@ -246,7 +246,6 @@ def test_disagg_ragged_categorical(state_data):
 
 
 # def test_disagg_continuous_age(age_group_data, age_subgroups):
-
 #     disagg = disaggregate(
 #         supergroup_df=age_group_data,
 #         subgroup_df=age_subgroups,

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -199,7 +199,7 @@ def test_data_io_age_groups(age_subgroups, age_group_data):
     )
 
 
-def test_disagg_ragged_categorical(state_data):
+def test_disagg_categorical(state_data):
     subgroup_df = pl.DataFrame(
         {
             "state": ["California", "California", "Washington", "Washington"],

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -2,6 +2,7 @@ import pytest
 
 from cfa_subgroup_imputer.variables import (
     Attribute,
+    ImputableAttribute,
     Range,
     assert_range_spanned_exactly,
 )
@@ -26,6 +27,41 @@ class TestAttribute:
         ) == Attribute(
             name="Outis", value=[dict(), tuple(), ""], impute_action="copy"
         )
+        assert ImputableAttribute(
+            name="attribute",
+            value=42,
+            impute_action="impute",
+            measurement_type="rate",
+        ) == ImputableAttribute(
+            name="attribute",
+            value=42,
+            impute_action="impute",
+            measurement_type="rate",
+        )
+        with pytest.raises(Exception):
+            assert Attribute(
+                name="Ourobouros",
+                value=[dict(), tuple(), ""],
+                impute_action="copy",
+            ) == Attribute(
+                name="Outis", value=[dict(), tuple(), ""], impute_action="copy"
+            )
+        with pytest.raises(Exception):
+            assert Attribute(
+                name="Outis",
+                value=[dict(), tuple()],
+                impute_action="copy",
+            ) == Attribute(
+                name="Outis", value=[dict(), tuple(), ""], impute_action="copy"
+            )
+        with pytest.raises(Exception):
+            assert Attribute(
+                name="Outis",
+                value=[dict(), tuple(), ""],
+                impute_action="ignore",
+            ) == Attribute(
+                name="Outis", value=[dict(), tuple(), ""], impute_action="copy"
+            )
 
 
 def test_range():


### PR DESCRIPTION
This PR adds both "core" disaggregation and a polars interface for it.

A large number of methods which were stubs are now implemented, and some methods which turned out to be needed and hadn't been anticipated have been added.

### Big picture

We can now input a dataframe on supergroups like so
```
┌────────────┬──────┬───────────────────────────┬───────────┬────────────┬────────────┬───────────┐
│ state      ┆ size ┆ flower                    ┆ some_rate ┆ some_count ┆ to_exclude ┆ to_ignore │
│ ---        ┆ ---  ┆ ---                       ┆ ---       ┆ ---        ┆ ---        ┆ ---       │
│ str        ┆ i64  ┆ str                       ┆ f64       ┆ i64        ┆ str        ┆ str       │
╞════════════╪══════╪═══════════════════════════╪═══════════╪════════════╪════════════╪═══════════╡
│ California ┆ 40   ┆ Eschscholzia californica  ┆ 1.2       ┆ 10         ┆ wont       ┆ willbe    │
│ Washington ┆ 8    ┆ Rhododendron macrophyllum ┆ 1.3       ┆ 20         ┆ see        ┆ ignored   │
└────────────┴──────┴───────────────────────────┴───────────┴────────────┴────────────┴───────────┘
```

and a dataframe on subgroups like so

```
┌────────────┬──────────┬──────┐
│ state      ┆ splitvar ┆ size │
│ ---        ┆ ---      ┆ ---  │
│ str        ┆ str      ┆ i64  │
╞════════════╪══════════╪══════╡
│ California ┆ cat1     ┆ 20   │
│ California ┆ cat2     ┆ 20   │
│ Washington ┆ cat1     ┆ 2    │
│ Washington ┆ cat2     ┆ 6    │
└────────────┴──────────┴──────┘
```

and using `cfa_subgroup_imputer.polars.disaggregate()` get an output like so

```
┌────────────┬──────────┬──────┬───────────────────────────┬───────────┬────────────┐
│ state      ┆ splitvar ┆ size ┆ flower                    ┆ some_rate ┆ some_count │
│ ---        ┆ ---      ┆ ---  ┆ ---                       ┆ ---       ┆ ---        │
│ str        ┆ str      ┆ i64  ┆ str                       ┆ f64       ┆ f64        │
╞════════════╪══════════╪══════╪═══════════════════════════╪═══════════╪════════════╡
│ California ┆ cat1     ┆ 20   ┆ Eschscholzia californica  ┆ 1.2       ┆ 5.0        │
│ California ┆ cat2     ┆ 20   ┆ Eschscholzia californica  ┆ 1.2       ┆ 5.0        │
│ Washington ┆ cat1     ┆ 2    ┆ Rhododendron macrophyllum ┆ 1.3       ┆ 5.0        │
│ Washington ┆ cat2     ┆ 6    ┆ Rhododendron macrophyllum ┆ 1.3       ┆ 15.0       │
└────────────┴──────────┴──────┴───────────────────────────┴───────────┴────────────┘
```

The user is responsible for specifying whether values in the supergroup dataframe are to be `exclude`d (they should not end up in the disaggregated subgroup output) or not. By default everything\* else is copied as-is to the disaggregated data, unless you say it's a rate or a count measurement, then it's imputed accordingly. We don't guess because we don't know what is a rate and what is a count. (We kind of implicitly guess because copying is the same as imputing rates, at least in the simple cases we currently cover, we could exclude all numerics instead?)

\*Everything that doesn't define the sub/supergroups or group sizes. We don't copy "age" or "size" columns when disaggregating, that would be silly.

### Implementation

In general, I pushed the actual _doing_ of things as far down the hierarchy as I could, which made testing much easier. Thus:
- The core `Disaggregator` class is basically a glorified loop
  - The `ProportionCalculator` Protocol is the thing that actually computes disaggregation weights
  - A `Group` is in charge of creating a new group during disaggregation, the `Disaggregator` merely tells it what the new group should be named and what percent of counts it gets.
- A `GroupMap`, other than bundling together data-containing sub/super `Group`s with their mapping, is basically a set of batch I/O functionality for putting data into and getting it out of the `Group`s.
  - A `Group` is in charge of outputting polars-convertable data formats and knowing how to filter a dataframe to get the information it needs out of it.
  - The notable exception is when getting data from polars into the `Group`s, where the polars interface logic is handled here, rather than wasting computation and argument passing doing it per-`Group` per `Attribute`.
- The classes in `cfa_subgroup_imputer.polars` are mostly extracting things from dataframes to pass to the core functionality.

### Misc and potentially out of scope cleaning

- There were lingering mass/density bits when we resolved to move to count/rate, which I fixed.
- There were some lingering GroupMap methods that were written speculatively and proved unnecessary, which I removed.